### PR TITLE
Add alt text for UNVT logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <div class="header wrap"><span class="header left-side"><a class="site home" href="/"><span class="site name">UNVT Dashboard</span></a></span>
         <span class="header right-side"><div class="nav wrap"><nav class="nav"><a class="nav item" href="https://github%2ecom/unvt"target="_blank">Github</a><a class="nav item" href="https://gohugo%2eio/"target="_blank">Hugo</a></nav></div></span></div></section><section id="content"><article class="article markdown-body"><h1 id="-unvt-dashboard-">🇺🇳 UNVT Dashboard 🗺️</h1>
 <p><img  src="https://un-vector-tile-toolkit.github.io/signature/logo.png"
-        alt/></p>
+        alt="UNVT logo"/></p>
 <h1 id="ℹ-what-is-unvt">ℹ️ What is UNVT?</h1>
 <p>The United Nations Vector Tile Toolkit (UNVT) is a collection of Open Source Software (OSS) to produce, host, style and optimize vector tiles for web mapping.</p>
 <h1 id="ℹ-projects">ℹ️ Projects</h1>


### PR DESCRIPTION
## Summary
- add descriptive alt text for the UNVT logo image

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684184f5747483258ba2dac07d945b7a