### PR TITLE
Add auto build workflow

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -1,0 +1,33 @@
+name: Build and deploy site
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - name: Commit built files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist .nojekyll
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update site [skip ci]"
+            git push origin HEAD:master
+          fi
+

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Run the build command which outputs to the `dist/` directory. A `.nojekyll` file
 npm run build
 ```
 
-The contents of `dist/` are committed to the repository and served from GitHub Pages.
+The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `master`, a GitHub Actions workflow automatically runs this build and updates the site.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds and commits on pushes to master
- update README to mention new automation

## Testing
- `git status --short`
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842d071ac608325b726178d94691a03