### PR TITLE
Update workflow for gh-pages deploy

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -3,7 +3,7 @@ name: Build and deploy site
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -28,6 +28,6 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Update site [skip ci]"
-            git push origin HEAD:master
+            git push origin HEAD:gh-pages
           fi
 

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Run the build command which outputs to the `dist/` directory. A `.nojekyll` file
 npm run build
 ```
 
-The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `master`, a GitHub Actions workflow automatically runs this build and updates the site.
+The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `main`, a GitHub Actions workflow automatically runs this build and pushes the updated site to the `gh-pages` branch.


### PR DESCRIPTION
## Summary
- update the deployment branch in the workflow
- explain new `gh-pages` flow in README

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842d173d2748325baebf019b2700e74