### PR TITLE
Switch GitHub Actions trigger to master

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -3,7 +3,7 @@ name: Build and deploy site
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Run the build command which outputs to the `dist/` directory. A `.nojekyll` file
 npm run build
 ```
 
-The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `main`, a GitHub Actions workflow automatically runs this build and pushes the updated site to the `gh-pages` branch.
+The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `master`, a GitHub Actions workflow automatically runs this build and pushes the updated site to the `gh-pages` branch.


### PR DESCRIPTION
## Summary
- trigger the deploy workflow from `master` instead of `main`
- update the README to mention `master`

After merging, ensure GitHub Pages is configured to deploy from the `gh-pages` branch so the site appears at <https://unvt.github.io/>.


------
https://chatgpt.com/codex/tasks/task_e_6842d36b165c8325bbd96cbc01c07a43