### PR TITLE
Enable manual deploy action

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Run the build command which outputs to the `dist/` directory. A `.nojekyll` file
 npm run build
 ```
 
-The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `master`, a GitHub Actions workflow automatically runs this build and pushes the updated site to the `gh-pages` branch.
+The contents of `dist/` are committed to the repository and served from GitHub Pages. Whenever changes are merged into `master`, a GitHub Actions workflow automatically runs this build and pushes the updated site to the `gh-pages` branch. The same workflow can also be triggered manually from the Actions tab if an immediate deploy is needed.


### PR DESCRIPTION
## Summary
- allow manual dispatch for `Build and deploy site` workflow
- document that the workflow can be run from the Actions tab

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842d4df98d88325b1fd696987168b6a