### PR TITLE
Fix GitHub Pages deploy to always push

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -25,10 +25,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add dist .nojekyll
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Update site [skip ci]"
-            git push origin HEAD:gh-pages
-          fi
+          git commit --allow-empty -m "Update site [skip ci]"
+          git push origin HEAD:gh-pages
 


### PR DESCRIPTION
## Summary
- always push to `gh-pages` by committing with `--allow-empty`

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842d5a4a58083258cb6498f3fb5b4f2